### PR TITLE
offset-based field

### DIFF
--- a/core/src/chain.rs
+++ b/core/src/chain.rs
@@ -19,14 +19,8 @@ impl<A, B> Chain<A, B> {
 }
 
 unsafe impl<A: Field, B: Field<Parent = A::Type>> Field for Chain<A, B> {
-    type Name = core::iter::Chain<A::Name, B::Name>;
     type Parent = A::Parent;
     type Type = B::Type;
-
-    #[inline]
-    fn name(&self) -> Self::Name {
-        self.a.name().chain(self.b.name())
-    }
 
     #[inline]
     unsafe fn project_raw(

--- a/core/src/dynamic.rs
+++ b/core/src/dynamic.rs
@@ -3,7 +3,11 @@ use core::marker::PhantomData;
 use crate::Field;
 
 struct Invariant<T: ?Sized>(fn() -> *mut T);
-/// A runtime offset based `Field`.
+
+/// A runtime offset based `Field`. This is a more efficient version
+/// of `dyn Field<Parent = P, Type = T, Name = N>`.
+///
+/// Generated from [`Field::dynamic`]
 pub struct Dynamic<P: ?Sized, T, N> {
     offset: usize,
     name:   N,
@@ -20,15 +24,24 @@ impl<P: ?Sized, T, N: Clone> Clone for Dynamic<P, T, N> {
     }
 }
 
-impl<P: ?Sized, T, N> Dynamic<P, T, N> {
-    pub(crate) unsafe fn from_raw_parts(offset: usize, name: N) -> Self {
+impl<P: ?Sized, T, N: Iterator<Item = &'static str> + Clone> Dynamic<P, T, N> {
+    /// Create a dynamic field from an offset and a name iterator.
+    ///
+    /// # Safety
+    ///
+    /// * `offset` - must be the offset in *bytes* from the start of `P`
+    ///              to a field/sub-field of type `T`
+    /// * `name`   - The fully qualified name of the field
+    pub unsafe fn from_raw_parts(offset: usize, name: N) -> Self {
         Self {
             offset,
             name,
             mark: PhantomData,
         }
     }
+}
 
+impl<P: ?Sized, T, N> Dynamic<P, T, N> {
     /// Get the offset
     pub fn offset(&self) -> usize {
         self.offset

--- a/core/src/dynamic.rs
+++ b/core/src/dynamic.rs
@@ -1,0 +1,69 @@
+use core::marker::PhantomData;
+
+use crate::Field;
+
+struct Invariant<T: ?Sized>(fn() -> *mut T);
+/// A runtime offset based `Field`.
+pub struct Dynamic<P: ?Sized, T, N> {
+    offset: usize,
+    name:   N,
+    mark:   PhantomData<Invariant<(T, P)>>,
+}
+
+impl<P: ?Sized, T, N: Clone> Clone for Dynamic<P, T, N> {
+    fn clone(&self) -> Self {
+        Self {
+            offset: self.offset,
+            name:   self.name.clone(),
+            mark:   PhantomData,
+        }
+    }
+}
+
+impl<P: ?Sized, T, N> Dynamic<P, T, N> {
+    pub(crate) unsafe fn from_raw_parts(offset: usize, name: N) -> Self {
+        Self {
+            offset,
+            name,
+            mark: PhantomData,
+        }
+    }
+
+    /// Get the offset
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+}
+
+unsafe impl<P: ?Sized, T: Field, N: Iterator<Item = &'static str> + Clone> Field
+    for Dynamic<P, T, N>
+{
+    type Name = N;
+    type Parent = P;
+    type Type = T;
+
+    fn name(&self) -> Self::Name {
+        self.name.clone()
+    }
+
+    unsafe fn project_raw(
+        &self,
+        ptr: *const Self::Parent,
+    ) -> *const Self::Type {
+        ptr.cast::<u8>().add(self.offset).cast()
+    }
+
+    unsafe fn project_raw_mut(
+        &self,
+        ptr: *mut Self::Parent,
+    ) -> *mut Self::Type {
+        ptr.cast::<u8>().add(self.offset).cast()
+    }
+
+    fn field_offset(&self) -> usize
+    where
+        Self::Parent: Sized,
+    {
+        self.offset
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -204,12 +204,42 @@ pub unsafe trait Field {
     /// The type of the field itself
     type Type: ?Sized;
 
-    /// An iterator that returns the fuully qualified name of the field
+    /// An iterator that returns the fully qualified name of the field
     type Name: Iterator<Item = &'static str> + Clone;
 
     /// An iterator that returns the fully qualified name of the field
     ///
-    /// This must be unique for each field of the given `Parent` type
+    /// # Safety:
+    ///
+    /// * The results of the iterator must be unique for each field
+    ///   of the given `Parent` type
+    /// * `Self::name` never returns an empty iterator.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// struct Foo {
+    ///     x: u32,
+    ///     bar: Bar,
+    /// }
+    ///
+    /// struct Bar {
+    ///     y: u32,
+    ///     yak: Yak,
+    /// }
+    ///
+    /// struct Yak {
+    ///     z: u32,
+    ///     // other fields
+    /// }
+    /// ```
+    ///
+    /// The field `foo.bar.yak.z` has the name `["bar", "yak", "z"]`.
+    ///
+    /// The name determines overlaps, in the following way:
+    ///
+    /// * Given two field types `a: A` and `b: B`, and `A::Parent == B::Parent`
+    /// * `overlap(a, b) => a.name().zip(b.name()).all(|(a_name, b_name)| a_name == b_name)`
     fn name(&self) -> Self::Name;
 
     /// projects the raw pointer from the `Parent` type to the field `Type`

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -30,13 +30,8 @@ macro_rules! field {
 
         #[deny(safe_packed_borrows)]
         unsafe impl $crate::Field for $field_ty_name {
-            type Name = $crate::macros::Once<&'static str>;
             type Parent = $parent;
             type Type = $field_ty;
-
-            fn name(&self) -> Self::Name {
-                $crate::macros::once(stringify!($field))
-            }
 
             #[inline]
             unsafe fn project_raw(

--- a/core/src/pin.rs
+++ b/core/src/pin.rs
@@ -21,14 +21,8 @@ pub struct PinToPin<F: Field + ?Sized> {
 }
 
 unsafe impl<F: ?Sized + Field> Field for PinToPin<F> {
-    type Name = F::Name;
     type Parent = F::Parent;
     type Type = F::Type;
-
-    #[inline]
-    fn name(&self) -> Self::Name {
-        F::name(&self.field)
-    }
 
     #[inline]
     unsafe fn project_raw(
@@ -48,14 +42,8 @@ unsafe impl<F: ?Sized + Field> Field for PinToPin<F> {
 }
 
 unsafe impl<F: ?Sized + Field> Field for PinToPtr<F> {
-    type Name = F::Name;
     type Parent = F::Parent;
     type Type = F::Type;
-
-    #[inline]
-    fn name(&self) -> Self::Name {
-        F::name(&self.0)
-    }
 
     #[inline]
     unsafe fn project_raw(
@@ -93,8 +81,7 @@ impl<F: Field> PinToPin<F> {
     #[inline]
     pub fn as_dyn_pin(
         &self,
-    ) -> PinToPin<&dyn Field<Parent = F::Parent, Type = F::Type, Name = F::Name>>
-    {
+    ) -> PinToPin<&dyn Field<Parent = F::Parent, Type = F::Type>> {
         PinToPin {
             field: &self.field
         }
@@ -139,8 +126,7 @@ impl<F: Field> PinToPtr<F> {
     #[inline]
     pub fn as_dyn_pin(
         &self,
-    ) -> PinToPtr<&dyn Field<Parent = F::Parent, Type = F::Type, Name = F::Name>>
-    {
+    ) -> PinToPtr<&dyn Field<Parent = F::Parent, Type = F::Type>> {
         PinToPtr(&self.0)
     }
 }

--- a/core/src/project.rs
+++ b/core/src/project.rs
@@ -58,14 +58,26 @@ type_function! {
     }
 
     for(I: Field, J: Field)
-    fn(self: FindOverlapInner<I>, input: J) -> bool {
+    fn(self: FindOverlapInner<I>, input: J) -> bool
+    where(
+        I::Parent: Sized,
+        J::Parent: Sized,
+        I::Type: Sized,
+        J::Type: Sized,
+    ){
         self.counter += 1;
 
         if self.id <= self.counter {
             return false
         }
 
-        self.field.name().zip(input.name())
-            .all(|(i, j)| i == j)
+        let field = self.field.range();
+        let input = input.range();
+
+        is_overlapping(field, input)
     }
+}
+
+fn is_overlapping(a: Range<usize>, b: Range<usize>) -> bool {
+    a.contains(&b.start) || a.contains(&b.end)
 }

--- a/core/src/set/tuple.rs
+++ b/core/src/set/tuple.rs
@@ -23,10 +23,12 @@
 #[macro_export]
 macro_rules! type_function {
     (
-        $($(for($($g_params:tt)*))? fn($self:ident:$func:ty $(, $param:ident: $type:ty )* $(,)? ) -> $output:ty $block:block)*
+        $($(for($($g_params:tt)*))? fn($self:ident:$func:ty $(, $param:ident: $type:ty )* $(,)? ) -> $output:ty $(where ($($where_clause:tt)*))? $block:block)*
     ) => {$(
         #[allow(unused_parens)]
-        impl $(<$($g_params)*>)? $crate::set::tuple::TypeFunction<($($type),*)> for $func {
+        impl $(<$($g_params)*>)? $crate::set::tuple::TypeFunction<($($type),*)> for $func
+        $(where $($where_clause)*)?
+        {
             type Output = $output;
 
             #[inline]

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -99,11 +99,6 @@ use syn;
 ///     unsafe impl ::gfp_core::Field for name<super::Person> {
 ///         type Parent = super::Person;
 ///         type Type = String;
-///         type Name = ::gfp_core::derive::Once<&'static str>;
-///         #[inline]
-///         fn name(&self) -> Self::Name {
-///             ::gfp_core::derive::once("name")
-///         }
 ///         #[inline]
 ///         unsafe fn project_raw(&self, ptr: *const Self::Parent) -> *const Self::Type {
 ///             &raw const (*ptr).name
@@ -130,11 +125,6 @@ use syn;
 ///     unsafe impl ::gfp_core::Field for age<super::Person> {
 ///         type Parent = super::Person;
 ///         type Type = u16;
-///         type Name = ::gfp_core::derive::Once<&'static str>;
-///         #[inline]
-///         fn name(&self) -> Self::Name {
-///             ::gfp_core::derive::once("age")
-///         }
 ///         #[inline]
 ///         unsafe fn project_raw(&self, ptr: *const Self::Parent) -> *const Self::Type {
 ///             &raw const (*ptr).age
@@ -161,11 +151,6 @@ use syn;
 ///     unsafe impl ::gfp_core::Field for children<super::Person> {
 ///         type Parent = super::Person;
 ///         type Type = Vec<Person>;
-///         type Name = ::gfp_core::derive::Once<&'static str>;
-///         #[inline]
-///         fn name(&self) -> Self::Name {
-///             ::gfp_core::derive::once("children")
-///         }
 ///         #[inline]
 ///         unsafe fn project_raw(&self, ptr: *const Self::Parent) -> *const Self::Type {
 ///             &raw const (*ptr).children
@@ -295,12 +280,6 @@ fn derive_named(ty: syn::DeriveInput) -> TokenStream {
             unsafe impl #generic_header ::gfp_core::Field for #ident<super::#input_ident #generic> {
                 type Parent = super::#input_ident #generic;
                 type Type = #ty;
-                type Name = ::gfp_core::derive::Once<&'static str>;
-
-                #[inline]
-                fn name(&self) -> Self::Name {
-                    ::gfp_core::derive::once(stringify!(#ident))
-                }
 
                 #[inline]
                 unsafe fn project_raw(&self, ptr: *const Self::Parent) -> *const Self::Type {
@@ -431,12 +410,6 @@ fn derive_unnamed(ty: syn::DeriveInput) -> TokenStream {
             unsafe impl #generic_header ::gfp_core::Field for #ident<super::#input_ident #generic> {
                 type Parent = super::#input_ident #generic;
                 type Type = #ty;
-                type Name = ::gfp_core::derive::Once<&'static str>;
-
-                #[inline]
-                fn name(&self) -> Self::Name {
-                    ::gfp_core::derive::once(stringify!(#index))
-                }
 
                 #[inline]
                 unsafe fn project_raw(&self, ptr: *const Self::Parent) -> *const Self::Type {
@@ -553,12 +526,6 @@ fn derive_union(ty: syn::DeriveInput) -> TokenStream {
             unsafe impl #generic_header ::gfp_core::Field for #ident<super::#input_ident #generic> {
                 type Parent = super::#input_ident #generic;
                 type Type = #ty;
-                type Name = ::gfp_core::derive::Once<&'static str>;
-
-                #[inline]
-                fn name(&self) -> Self::Name {
-                    ::gfp_core::derive::once(stringify!(#input_ident))
-                }
 
                 #[inline]
                 unsafe fn project_raw(&self, ptr: *const Self::Parent) -> *const Self::Type {


### PR DESCRIPTION
Fixes #33

This initial implementation just stores an offset and clones the `Name` iterator. Eventually the `Name` iterator should be removed and replaced with a way that can be type-erased.