### PR TITLE
add unchecked projections trait

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,6 +15,7 @@ mod dynamic;
 pub mod macros;
 mod pin;
 mod project;
+mod unchecked_project;
 
 #[doc(hidden)]
 pub mod type_list;
@@ -59,6 +60,46 @@ pub trait ProjectTo<F: Field> {
 
     /// projects to the given field
     fn project_to(self, field: F) -> Self::Projection;
+}
+
+// TODO: reword this documentation, tis bad
+/// Projects a type to the given field
+///
+/// The safety condition of this projection depends on the type
+/// that implements this trait.
+///
+/// * For `*const T`, `*mut T`, and `NonNull<T>`, it's the same as
+///   `project_raw`/`project_raw_mut`
+/// * For `Option<T>`, if it is `Some`, then the safety condtion on `T`
+///   applies, otherwise there is no safety condition
+pub trait UncheckedProjectTo<F: Field> {
+    /// The projection of the type, can be used to directly access the field
+    type Projection;
+
+    /// projects to the given field
+    ///
+    /// Safety: see type documentation
+    unsafe fn project_to(self, field: F) -> Self::Projection;
+}
+
+// TODO: reword this documentation, tis bad
+/// Projects a field to it's parent
+///
+/// The safety condition of this projection depends on the type
+/// that implements this trait.
+///
+/// * For `*const T`, `*mut T`, and `NonNull<T>`, it's the same as
+///   `inverse_project_raw`/`inverse_project_raw_mut`
+/// * For `Option<T>`, if it is `Some`, then the safety condtion on `T`
+///   applies, otherwise there is no safety condition
+pub trait UncheckedInverseProjectTo<F: Field> {
+    /// The projection of the type, can be used to directly access the field
+    type Projection;
+
+    /// projects to the parent
+    ///
+    /// Safety: see type documentation
+    unsafe fn inverse_project_to(self, field: F) -> Self::Projection;
 }
 
 /// Projects a type to the given field list

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -56,7 +56,7 @@ pub mod derive {
 /// Projects a type to the given field
 pub trait ProjectTo<F: Field> {
     /// The projection of the type, can be used to directly access the field
-    type Projection: core::ops::Deref<Target = F::Type>;
+    type Projection;
 
     /// projects to the given field
     fn project_to(self, field: F) -> Self::Projection;

--- a/core/src/project.rs
+++ b/core/src/project.rs
@@ -16,6 +16,17 @@ use core::{marker::PhantomData, ops::Deref, pin::Pin};
 
 use crate::pin::*;
 
+impl<F: Field, T: ProjectTo<F>> ProjectTo<F> for Option<T> {
+    type Projection = Option<T::Projection>;
+
+    fn project_to(self, field: F) -> Self::Projection {
+        match self {
+            Some(value) => Some(value.project_to(field)),
+            None => None,
+        }
+    }
+}
+
 pub struct PtrToRef<'a>(PhantomData<&'a ()>);
 
 typsy::call! {

--- a/core/src/unchecked_project.rs
+++ b/core/src/unchecked_project.rs
@@ -1,0 +1,75 @@
+use crate::{Field, UncheckedInverseProjectTo, UncheckedProjectTo};
+
+use core::ptr::NonNull;
+
+impl<F: Field> UncheckedProjectTo<F> for *const F::Parent {
+    type Projection = *const F::Type;
+
+    unsafe fn project_to(self, field: F) -> Self::Projection {
+        field.project_raw(self)
+    }
+}
+
+impl<F: Field> UncheckedInverseProjectTo<F> for *const F::Type {
+    type Projection = *const F::Parent;
+
+    unsafe fn inverse_project_to(self, field: F) -> Self::Projection {
+        field.inverse_project_raw(self)
+    }
+}
+
+impl<F: Field> UncheckedProjectTo<F> for *mut F::Parent {
+    type Projection = *mut F::Type;
+
+    unsafe fn project_to(self, field: F) -> Self::Projection {
+        field.project_raw_mut(self)
+    }
+}
+
+impl<F: Field> UncheckedInverseProjectTo<F> for *mut F::Type {
+    type Projection = *mut F::Parent;
+
+    unsafe fn inverse_project_to(self, field: F) -> Self::Projection {
+        field.inverse_project_raw_mut(self)
+    }
+}
+
+impl<F: Field> UncheckedProjectTo<F> for NonNull<F::Parent> {
+    type Projection = NonNull<F::Type>;
+
+    unsafe fn project_to(self, field: F) -> Self::Projection {
+        NonNull::new_unchecked(field.project_raw_mut(self.as_ptr()))
+    }
+}
+
+impl<F: Field> UncheckedInverseProjectTo<F> for NonNull<F::Type> {
+    type Projection = NonNull<F::Parent>;
+
+    unsafe fn inverse_project_to(self, field: F) -> Self::Projection {
+        NonNull::new_unchecked(field.inverse_project_raw_mut(self.as_ptr()))
+    }
+}
+
+impl<F: Field, T: UncheckedProjectTo<F>> UncheckedProjectTo<F> for Option<T> {
+    type Projection = Option<T::Projection>;
+
+    unsafe fn project_to(self, field: F) -> Self::Projection {
+        match self {
+            Some(value) => Some(value.project_to(field)),
+            None => None,
+        }
+    }
+}
+
+impl<F: Field, T: UncheckedInverseProjectTo<F>> UncheckedInverseProjectTo<F>
+    for Option<T>
+{
+    type Projection = Option<T::Projection>;
+
+    unsafe fn inverse_project_to(self, field: F) -> Self::Projection {
+        match self {
+            Some(value) => Some(value.inverse_project_to(field)),
+            None => None,
+        }
+    }
+}

--- a/core/tests/unchecked.rs
+++ b/core/tests/unchecked.rs
@@ -1,0 +1,62 @@
+#![feature(raw_ref_op)]
+#![allow(non_camel_case_types, clippy::blacklisted_name)]
+
+use std::ptr::NonNull;
+
+use gfp_core::*;
+
+#[derive(Default, Field)]
+struct Foo {
+    x: u8,
+    y: Bar,
+    z: u128,
+}
+
+#[derive(Default, Field)]
+struct Bar {
+    a: u16,
+    b: u32,
+    c: Quaz,
+}
+
+#[derive(Default, Field)]
+struct Quaz {
+    q: (u16, u32),
+    r: u32,
+}
+
+#[derive(Field)]
+struct MyType<T> {
+    x: u8,
+    y: u8,
+    z: T,
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn test_nonnull() {
+    let foo = Foo::default();
+    let foo_addr = &foo as *const Foo as usize;
+    let nn_foo = NonNull::from(&foo);
+    let Foo = Foo::fields();
+    let Bar = Bar::fields();
+    let nn_foo_y_b = unsafe { nn_foo.project_to(Foo.y.chain(Bar.b)) };
+    let offset = nn_foo_y_b.as_ptr() as usize - foo_addr;
+    assert_eq!(offset, Foo.y.chain(Bar.b).field_offset())
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn test_option() {
+    let foo = Foo::default();
+    let mut opt_nn_foo = Some(NonNull::from(&foo));
+    let nn_foo = NonNull::from(&foo);
+    let Foo = Foo::fields();
+    let Bar = Bar::fields();
+    let opt_nn_foo_y_b = unsafe { opt_nn_foo.project_to(Foo.y.chain(Bar.b)) };
+    let nn_foo_y_b = unsafe { nn_foo.project_to(Foo.y.chain(Bar.b)) };
+    assert_eq!(opt_nn_foo_y_b, Some(nn_foo_y_b));
+    opt_nn_foo = None;
+    let nn_foo_y_b = unsafe { opt_nn_foo.project_to(Foo.y.chain(Bar.b)) };
+    assert!(nn_foo_y_b.is_none());
+}


### PR DESCRIPTION
This allows generalizing over other pointer types, like `NonNull` and `Option<NonNulll>`, which are useful if you want to enforce a `project` if non-null property.